### PR TITLE
fix!: remove @libp2p/components

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,15 +24,14 @@ $ npm i @chainsafe/libp2p-yamux
 ## Usage
 
 ```js
-import { YamuxMuxer } from '@chainsafe/libp2p-yamux'
-import { Components } from '@libp2p/interfaces/components'
+import { yamux } from '@chainsafe/libp2p-yamux'
 import { pipe } from 'it-pipe'
 import { duplexPair } from 'it-pair/duplex'
 import all from 'it-all'
 
 // Connect two yamux muxers to demo basic stream multiplexing functionality
 
-const clientMuxer = new YamuxMuxer(new Components(), {
+const clientMuxer = yamux({
   client: true,
   onIncomingStream: stream => {
     // echo data on incoming streams
@@ -41,9 +40,9 @@ const clientMuxer = new YamuxMuxer(new Components(), {
   onStreamEnd: stream => {
     // do nothing
   }
-})
+})()
 
-const serverMuxer = new YamuxMuxer(new Components(), {
+const serverMuxer = yamux({
   client: false,
   onIncomingStream: stream => {
     // echo data on incoming streams
@@ -52,7 +51,7 @@ const serverMuxer = new YamuxMuxer(new Components(), {
   onStreamEnd: stream => {
     // do nothing
   }
-})
+})()
 
 // `p` is our "connections", what we use to connect the two sides
 // In a real application, a connection is usually to a remote computer

--- a/package.json
+++ b/package.json
@@ -170,8 +170,8 @@
     "release": "aegir release"
   },
   "dependencies": {
-    "@libp2p/components": "^3.0.0",
     "@libp2p/interface-connection": "^3.0.1",
+    "@libp2p/interface-metrics": "^3.0.0",
     "@libp2p/interface-stream-muxer": "^3.0.0",
     "@libp2p/logger": "^2.0.1",
     "@libp2p/tracked-map": "^2.0.2",
@@ -181,9 +181,9 @@
     "iso-random-stream": "^2.0.2",
     "it-pipe": "^2.0.4",
     "it-pushable": "^3.1.0",
-    "multiformats": "^9.7.1",
+    "multiformats": "^10.0.0",
     "uint8arraylist": "^2.3.2",
-    "uint8arrays": "^3.1.0"
+    "uint8arrays": "^4.0.2"
   },
   "devDependencies": {
     "@dapplion/benchmark": "^0.2.2",

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,2 +1,8 @@
+import type { StreamMuxerFactory } from '@libp2p/interface-stream-muxer'
+import { Yamux } from './muxer.js'
+import type { YamuxMuxerInit, YamuxComponents } from './muxer.js'
 export { GoAwayCode } from './frame.js'
-export * from './muxer.js'
+
+export function yamux (init: YamuxMuxerInit = {}): (components?: YamuxComponents) => StreamMuxerFactory {
+  return (components: YamuxComponents = {}) => new Yamux(components, init)
+}

--- a/test/compliance.spec.ts
+++ b/test/compliance.spec.ts
@@ -6,7 +6,7 @@ import { TestYamux } from './util.js'
 describe('compliance', () => {
   tests({
     async setup () {
-      return new TestYamux()
+      return new TestYamux({})
     },
     async teardown () {}
   })

--- a/test/util.ts
+++ b/test/util.ts
@@ -1,4 +1,3 @@
-import { Components } from '@libp2p/components'
 import { logger } from '@libp2p/logger'
 import type { Transform } from 'it-stream-types'
 import { duplexPair } from 'it-pair/duplex'
@@ -34,7 +33,7 @@ export class TestYamux extends Yamux {
 }
 
 export function testYamuxMuxer (name: string, client: boolean, conf: YamuxMuxerInit = {}) {
-  return new YamuxMuxer(new Components(), {
+  return new YamuxMuxer({}, {
     ...testConf,
     ...conf,
     direction: client ? 'outbound' : 'inbound',


### PR DESCRIPTION
`@libp2p/components` is a choke-point for our dependency graph as it depends on every interface, meaning when one interface revs a major `@libp2p/components` major has to change too which means every module depending on it also needs a major.

Switch instead to constructor injection of simple objects that let modules declare their dependencies on interfaces directly instead of indirectly via `@libp2p/components`

Refs https://github.com/libp2p/js-libp2p-components/issues/6

BREAKING CHANGE: modules no longer implement `Initializable` instead switching to constructor injection