### PR TITLE
fix: remove metrics from component

### DIFF
--- a/package.json
+++ b/package.json
@@ -171,10 +171,8 @@
   },
   "dependencies": {
     "@libp2p/interface-connection": "^3.0.1",
-    "@libp2p/interface-metrics": "^3.0.0",
     "@libp2p/interface-stream-muxer": "^3.0.0",
     "@libp2p/logger": "^2.0.1",
-    "@libp2p/tracked-map": "^2.0.2",
     "abortable-iterator": "^4.0.2",
     "any-signal": "^3.0.1",
     "err-code": "^3.0.1",

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,8 +1,8 @@
 import type { StreamMuxerFactory } from '@libp2p/interface-stream-muxer'
 import { Yamux } from './muxer.js'
-import type { YamuxMuxerInit, YamuxComponents } from './muxer.js'
+import type { YamuxMuxerInit } from './muxer.js'
 export { GoAwayCode } from './frame.js'
 
-export function yamux (init: YamuxMuxerInit = {}): (components?: YamuxComponents) => StreamMuxerFactory {
-  return (components: YamuxComponents = {}) => new Yamux(components, init)
+export function yamux (init: YamuxMuxerInit = {}): () => StreamMuxerFactory {
+  return () => new Yamux(init)
 }

--- a/test/util.ts
+++ b/test/util.ts
@@ -33,7 +33,7 @@ export class TestYamux extends Yamux {
 }
 
 export function testYamuxMuxer (name: string, client: boolean, conf: YamuxMuxerInit = {}) {
-  return new YamuxMuxer({}, {
+  return new YamuxMuxer({
     ...testConf,
     ...conf,
     direction: client ? 'outbound' : 'inbound',


### PR DESCRIPTION
Since muxers are factories there's no point tracking stream metrics for each instance as they trample over each other, so remove the use of tracked maps in this module.

This was added to mplex by mistake and copied here, but it's since been removed from mplex so this change brings yamux in line.