### PR TITLE
fix: catch stream sink errors

### DIFF
--- a/src/stream.ts
+++ b/src/stream.ts
@@ -142,6 +142,8 @@ export class YamuxStream implements Stream {
             data = data.subarray(toSend)
           }
         }
+      } catch (e) {
+        this.log?.('stream sink error id=%s', this._id, e)
       } finally {
         this.log?.('stream sink ended id=%s', this._id)
         this.closeWrite()


### PR DESCRIPTION
Resolves #23

The stream sink did not catch its own errors. This can lead to a situation where a thrown error can be unhandled.