### PR TITLE
fix: throw on stream reset

### DIFF
--- a/src/stream.ts
+++ b/src/stream.ts
@@ -164,7 +164,7 @@ export class YamuxStream implements Stream {
       }
     } catch (err) {
       const errCode = (err as { code: string }).code
-      if (errCode !== ERR_STREAM_ABORT && errCode !== ERR_STREAM_RESET) {
+      if (errCode !== ERR_STREAM_ABORT) {
         this.log?.error('stream source error id=%s', this._id, err)
         throw err
       }


### PR DESCRIPTION
Following the conversation [here](https://github.com/libp2p/js-libp2p/pull/1579#discussion_r1128830520) it seems that certain errors where not being propagated as an `ERR_STREAM_RESET`