### PR TITLE
deps: update any-signal to 4.x.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -176,7 +176,7 @@
     "@libp2p/interfaces": "^3.2.0",
     "@libp2p/logger": "^2.0.1",
     "abortable-iterator": "^4.0.2",
-    "any-signal": "^3.0.1",
+    "any-signal": "^4.1.1",
     "it-pipe": "^2.0.4",
     "it-pushable": "^3.1.0",
     "uint8arraylist": "^2.3.2"


### PR DESCRIPTION
`any-signal@4.x.x` adds a `.clear` function to remove abort listeners set up during creation which can causes memory leaks if the signals passed in are from very long-lived abort controllers.