### PR TITLE
fix: use trace logging for happy paths

### DIFF
--- a/src/muxer.ts
+++ b/src/muxer.ts
@@ -274,7 +274,11 @@ export class YamuxMuxer implements StreamMuxer {
     // If reason was provided, use that, otherwise use the presence of `err` to determine the reason
     reason = reason ?? (err === undefined ? GoAwayCode.InternalError : GoAwayCode.NormalTermination)
 
-    this.log?.trace('muxer close reason=%s error=%s', GoAwayCode[reason], err)
+    if (err != null) {
+      this.log?.error('muxer close reason=%s error=%s', GoAwayCode[reason], err)
+    } else {
+      this.log?.trace('muxer close reason=%s', GoAwayCode[reason])
+    }
 
     // If err is provided, abort all underlying streams, else close all underlying streams
     if (err === undefined) {

--- a/src/stream.ts
+++ b/src/stream.ts
@@ -114,7 +114,7 @@ export class YamuxStream implements Stream {
 
     this.sourceInput = pushable({
       onEnd: (err?: Error) => {
-        this.log?.('stream source ended id=%s', this._id, err)
+        this.log?.trace('stream source ended id=%s', this._id, err)
         this.closeRead()
       }
     })
@@ -145,7 +145,7 @@ export class YamuxStream implements Stream {
       } catch (e) {
         this.log?.error('stream sink error id=%s', this._id, e)
       } finally {
-        this.log?.('stream sink ended id=%s', this._id)
+        this.log?.trace('stream sink ended id=%s', this._id)
         this.closeWrite()
       }
     }
@@ -167,7 +167,7 @@ export class YamuxStream implements Stream {
   }
 
   close (): void {
-    this.log?.('stream close id=%s', this._id)
+    this.log?.trace('stream close id=%s', this._id)
     this.closeRead()
     this.closeWrite()
   }
@@ -181,7 +181,7 @@ export class YamuxStream implements Stream {
       return
     }
 
-    this.log?.('stream close read id=%s', this._id)
+    this.log?.trace('stream close read id=%s', this._id)
 
     this.readState = HalfStreamState.Closed
 
@@ -203,7 +203,7 @@ export class YamuxStream implements Stream {
       return
     }
 
-    this.log?.('stream close write id=%s', this._id)
+    this.log?.trace('stream close write id=%s', this._id)
 
     this.writeState = HalfStreamState.Closed
 
@@ -235,7 +235,7 @@ export class YamuxStream implements Stream {
         throw new Error('unreachable')
     }
 
-    this.log?.('stream abort id=%s error=%s', this._id, err)
+    this.log?.trace('stream abort id=%s error=%s', this._id, err)
 
     this.onReset(new CodeError(String(err) ?? 'stream aborted', ERR_STREAM_ABORT))
   }
@@ -245,7 +245,7 @@ export class YamuxStream implements Stream {
       return
     }
 
-    this.log?.('stream reset id=%s', this._id)
+    this.log?.trace('stream reset id=%s', this._id)
 
     this.onReset(new CodeError('stream reset', ERR_STREAM_RESET))
   }
@@ -301,7 +301,7 @@ export class YamuxStream implements Stream {
    * handleWindowUpdate is called when the stream receives a window update frame
    */
   handleWindowUpdate (header: FrameHeader): void {
-    this.log?.('stream received window update id=%s', this._id)
+    this.log?.trace('stream received window update id=%s', this._id)
     this.processFlags(header.flag)
 
     // increase send window
@@ -317,7 +317,7 @@ export class YamuxStream implements Stream {
    * handleData is called when the stream receives a data frame
    */
   async handleData (header: FrameHeader, readData: () => Promise<Uint8ArrayList>): Promise<void> {
-    this.log?.('stream received data id=%s', this._id)
+    this.log?.trace('stream received data id=%s', this._id)
     this.processFlags(header.flag)
 
     // check that our recv window is not exceeded
@@ -351,7 +351,7 @@ export class YamuxStream implements Stream {
    * finish sets the state and triggers eventual garbage collection of the stream
    */
   private finish (): void {
-    this.log?.('stream finished id=%s', this._id)
+    this.log?.trace('stream finished id=%s', this._id)
     this.state = StreamState.Finished
     this.stat.timeline.close = Date.now()
     this.onStreamEnd()

--- a/src/stream.ts
+++ b/src/stream.ts
@@ -114,7 +114,12 @@ export class YamuxStream implements Stream {
 
     this.sourceInput = pushable({
       onEnd: (err?: Error) => {
-        this.log?.trace('stream source ended id=%s', this._id, err)
+        if (err != null) {
+          this.log?.error('stream source ended id=%s', this._id, err)
+        } else {
+          this.log?.trace('stream source ended id=%s', this._id)
+        }
+
         this.closeRead()
       }
     })
@@ -235,7 +240,11 @@ export class YamuxStream implements Stream {
         throw new Error('unreachable')
     }
 
-    this.log?.trace('stream abort id=%s error=%s', this._id, err)
+    if (err != null) {
+      this.log?.error('stream abort id=%s error=%s', this._id, err)
+    } else {
+      this.log?.trace('stream abort id=%s', this._id)
+    }
 
     this.onReset(new CodeError(String(err) ?? 'stream aborted', ERR_STREAM_ABORT))
   }


### PR DESCRIPTION
Updates logging to use `.trace` where the code is on the happy path.

Being able to debug behaviour is useful but the logs are very noisy for when you're not debugging yamux.