### PR TITLE
deps!: update to new stream type deps

### DIFF
--- a/.github/workflows/js-test-and-release.yml
+++ b/.github/workflows/js-test-and-release.yml
@@ -2,7 +2,7 @@ name: test & maybe release
 on:
   push:
     branches:
-      - master # with #262 - ${{{ github.default_branch }}}
+      - master
   pull_request:
 
 jobs:
@@ -33,7 +33,7 @@ jobs:
           node-version: ${{ matrix.node }}
       - uses: ipfs/aegir/actions/cache-node-modules@master
       - run: npm run --if-present test:node
-      - uses: codecov/codecov-action@81cd2dc8148241f03f5839d295e000b8f761e378 # v3.1.0
+      - uses: codecov/codecov-action@d9f34f8cd5cb3b3eb79b3e4b5dae3a16df499a70 # v3.1.1
         with:
           flags: node
 
@@ -47,7 +47,7 @@ jobs:
           node-version: lts/*
       - uses: ipfs/aegir/actions/cache-node-modules@master
       - run: npm run --if-present test:chrome
-      - uses: codecov/codecov-action@81cd2dc8148241f03f5839d295e000b8f761e378 # v3.1.0
+      - uses: codecov/codecov-action@d9f34f8cd5cb3b3eb79b3e4b5dae3a16df499a70 # v3.1.1
         with:
           flags: chrome
 
@@ -61,7 +61,7 @@ jobs:
           node-version: lts/*
       - uses: ipfs/aegir/actions/cache-node-modules@master
       - run: npm run --if-present test:chrome-webworker
-      - uses: codecov/codecov-action@81cd2dc8148241f03f5839d295e000b8f761e378 # v3.1.0
+      - uses: codecov/codecov-action@d9f34f8cd5cb3b3eb79b3e4b5dae3a16df499a70 # v3.1.1
         with:
           flags: chrome-webworker
 
@@ -75,7 +75,7 @@ jobs:
           node-version: lts/*
       - uses: ipfs/aegir/actions/cache-node-modules@master
       - run: npm run --if-present test:firefox
-      - uses: codecov/codecov-action@81cd2dc8148241f03f5839d295e000b8f761e378 # v3.1.0
+      - uses: codecov/codecov-action@d9f34f8cd5cb3b3eb79b3e4b5dae3a16df499a70 # v3.1.1
         with:
           flags: firefox
 
@@ -89,9 +89,47 @@ jobs:
           node-version: lts/*
       - uses: ipfs/aegir/actions/cache-node-modules@master
       - run: npm run --if-present test:firefox-webworker
-      - uses: codecov/codecov-action@81cd2dc8148241f03f5839d295e000b8f761e378 # v3.1.0
+      - uses: codecov/codecov-action@d9f34f8cd5cb3b3eb79b3e4b5dae3a16df499a70 # v3.1.1
         with:
           flags: firefox-webworker
+
+  test-webkit:
+    needs: check
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest]
+        node: [lts/*]
+      fail-fast: true
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: lts/*
+      - uses: ipfs/aegir/actions/cache-node-modules@master
+      - run: npm run --if-present test:webkit
+      - uses: codecov/codecov-action@d9f34f8cd5cb3b3eb79b3e4b5dae3a16df499a70 # v3.1.1
+        with:
+          flags: webkit
+
+  test-webkit-webworker:
+    needs: check
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest]
+        node: [lts/*]
+      fail-fast: true
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: lts/*
+      - uses: ipfs/aegir/actions/cache-node-modules@master
+      - run: npm run --if-present test:webkit-webworker
+      - uses: codecov/codecov-action@d9f34f8cd5cb3b3eb79b3e4b5dae3a16df499a70 # v3.1.1
+        with:
+          flags: webkit-webworker
 
   test-electron-main:
     needs: check
@@ -103,7 +141,7 @@ jobs:
           node-version: lts/*
       - uses: ipfs/aegir/actions/cache-node-modules@master
       - run: npx xvfb-maybe npm run --if-present test:electron-main
-      - uses: codecov/codecov-action@81cd2dc8148241f03f5839d295e000b8f761e378 # v3.1.0
+      - uses: codecov/codecov-action@d9f34f8cd5cb3b3eb79b3e4b5dae3a16df499a70 # v3.1.1
         with:
           flags: electron-main
 
@@ -117,14 +155,14 @@ jobs:
           node-version: lts/*
       - uses: ipfs/aegir/actions/cache-node-modules@master
       - run: npx xvfb-maybe npm run --if-present test:electron-renderer
-      - uses: codecov/codecov-action@81cd2dc8148241f03f5839d295e000b8f761e378 # v3.1.0
+      - uses: codecov/codecov-action@d9f34f8cd5cb3b3eb79b3e4b5dae3a16df499a70 # v3.1.1
         with:
           flags: electron-renderer
 
   release:
-    needs: [test-node, test-chrome, test-chrome-webworker, test-firefox, test-firefox-webworker, test-electron-main, test-electron-renderer]
+    needs: [test-node, test-chrome, test-chrome-webworker, test-firefox, test-firefox-webworker, test-webkit, test-webkit-webworker, test-electron-main, test-electron-renderer]
     runs-on: ubuntu-latest
-    if: github.event_name == 'push' && github.ref == 'refs/heads/master' # with #262 - 'refs/heads/${{{ github.default_branch }}}'
+    if: github.event_name == 'push' && github.ref == 'refs/heads/master'
     steps:
       - uses: actions/checkout@v3
         with:
@@ -139,5 +177,5 @@ jobs:
           docker-username: ${{ secrets.DOCKER_USERNAME }}
       - run: npm run --if-present release
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.UCI_GITHUB_TOKEN || github.token }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,9 @@
 node_modules
+build
 dist
 .docs
 .coverage
+node_modules
 package-lock.json
 yarn.lock
+.vscode

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+  "typescript.tsdk": "node_modules/typescript/lib"
+}

--- a/package.json
+++ b/package.json
@@ -171,24 +171,24 @@
     "docs": "aegir docs"
   },
   "dependencies": {
-    "@libp2p/interface-connection": "^4.0.0",
-    "@libp2p/interface-stream-muxer": "^3.0.0",
+    "@libp2p/interface-connection": "^5.0.0",
+    "@libp2p/interface-stream-muxer": "^4.0.0",
     "@libp2p/interfaces": "^3.2.0",
     "@libp2p/logger": "^2.0.1",
     "abortable-iterator": "^4.0.2",
     "any-signal": "^4.1.1",
     "it-pipe": "^3.0.1",
-    "it-pushable": "^3.1.0",
+    "it-pushable": "^3.1.3",
     "uint8arraylist": "^2.3.2"
   },
   "devDependencies": {
     "@dapplion/benchmark": "^0.2.2",
-    "@libp2p/interface-stream-muxer-compliance-tests": "^6.0.0",
-    "@libp2p/mplex": "^7.0.0",
+    "@libp2p/interface-stream-muxer-compliance-tests": "^7.0.0",
+    "@libp2p/mplex": "^8.0.0",
     "aegir": "^38.1.0",
-    "it-drain": "^2.0.0",
-    "it-pair": "^2.0.4",
-    "it-stream-types": "^1.0.4"
+    "it-drain": "^3.0.1",
+    "it-pair": "^2.0.6",
+    "it-stream-types": "^2.0.1"
   },
   "browser": {}
 }

--- a/src/decode.ts
+++ b/src/decode.ts
@@ -29,16 +29,16 @@ export function decodeHeader (data: Uint8Array): FrameHeader {
  * Decodes yamux frames from a source
  */
 export class Decoder {
-  private readonly source: Source<Uint8Array>
+  private readonly source: Source<Uint8Array | Uint8ArrayList>
   /** Buffer for in-progress frames */
   private readonly buffer: Uint8ArrayList
   /** Used to sanity check against decoding while in an inconsistent state */
   private frameInProgress: boolean
 
-  constructor (source: Source<Uint8Array>) {
+  constructor (source: Source<Uint8Array | Uint8ArrayList>) {
     // Normally, when entering a for-await loop with an iterable/async iterable, the only ways to exit the loop are:
     // 1. exhaust the iterable
-    // 2. throw an error - slow, undesireable if there's not actually an error
+    // 2. throw an error - slow, undesirable if there's not actually an error
     // 3. break or return - calls the iterable's `return` method, finalizing the iterable, no more iteration possible
     //
     // In this case, we want to enter (and exit) a for-await loop per chunked data frame and continue processing the iterable.

--- a/src/muxer.ts
+++ b/src/muxer.ts
@@ -39,7 +39,7 @@ export class Yamux implements StreamMuxerFactory {
 export class YamuxMuxer implements StreamMuxer {
   protocol = YAMUX_PROTOCOL_ID
   source: Pushable<Uint8Array>
-  sink: Sink<Uint8Array>
+  sink: Sink<Source<Uint8ArrayList | Uint8Array>, Promise<void>>
 
   private readonly _init: YamuxMuxerInit
   private readonly config: Config
@@ -95,7 +95,7 @@ export class YamuxMuxer implements StreamMuxer {
       }
     })
 
-    this.sink = async (source: Source<Uint8Array>): Promise<void> => {
+    this.sink = async (source: Source<Uint8ArrayList | Uint8Array>): Promise<void> => {
       let signal: ClearableSignal | undefined
 
       if (this._init.signal != null) {

--- a/src/stream.ts
+++ b/src/stream.ts
@@ -51,9 +51,9 @@ export class YamuxStream implements Stream {
   /** Input to the read side of the stream */
   sourceInput: Pushable<Uint8ArrayList>
   /** Read side of the stream */
-  source: Source<Uint8ArrayList>
+  source: AsyncGenerator<Uint8ArrayList>
   /** Write side of the stream */
-  sink: Sink<Uint8Array | Uint8ArrayList>
+  sink: Sink<Source<Uint8ArrayList | Uint8Array>, Promise<void>>
 
   private readonly config: Config
   private readonly log?: Logger

--- a/test/mplex.util.ts
+++ b/test/mplex.util.ts
@@ -1,4 +1,4 @@
-import type { Transform } from 'it-stream-types'
+import type { Source, Transform } from 'it-stream-types'
 import { duplexPair } from 'it-pair/duplex'
 import { pipe } from 'it-pipe'
 import { mplex } from '@libp2p/mplex'
@@ -16,7 +16,7 @@ export function testYamuxMuxer (name: string, client: boolean, conf: StreamMuxer
 /**
  * Create a transform that can be paused and unpaused
  */
-export function pauseableTransform <A> (): { transform: Transform<A, A>, pause: () => void, unpause: () => void } {
+export function pauseableTransform <A> (): { transform: Transform<Source<A>, AsyncGenerator<A>>, pause: () => void, unpause: () => void } {
   let resolvePausePromise: ((value: unknown) => void) | undefined
   let pausePromise: Promise<unknown> | undefined
   const unpause = (): void => {
@@ -27,7 +27,7 @@ export function pauseableTransform <A> (): { transform: Transform<A, A>, pause: 
       resolvePausePromise = resolve
     })
   }
-  const transform: Transform<A, A> = async function * (source) {
+  const transform: Transform<Source<A>, AsyncGenerator<A>> = async function * (source) {
     for await (const d of source) {
       if (pausePromise !== undefined) {
         await pausePromise

--- a/test/util.ts
+++ b/test/util.ts
@@ -1,5 +1,5 @@
 import { logger } from '@libp2p/logger'
-import type { Transform } from 'it-stream-types'
+import type { Source, Transform } from 'it-stream-types'
 import { duplexPair } from 'it-pair/duplex'
 import { pipe } from 'it-pipe'
 import type { Config } from '../src/config.js'
@@ -44,7 +44,7 @@ export function testYamuxMuxer (name: string, client: boolean, conf: YamuxMuxerI
 /**
  * Create a transform that can be paused and unpaused
  */
-export function pauseableTransform <A> (): { transform: Transform<A, A>, pause: () => void, unpause: () => void } {
+export function pauseableTransform <A> (): { transform: Transform<Source<A>, AsyncGenerator<A>>, pause: () => void, unpause: () => void } {
   let resolvePausePromise: ((value: unknown) => void) | undefined
   let pausePromise: Promise<unknown> | undefined
   const unpause = (): void => {
@@ -55,7 +55,7 @@ export function pauseableTransform <A> (): { transform: Transform<A, A>, pause: 
       resolvePausePromise = resolve
     })
   }
-  const transform: Transform<A, A> = async function * (source) {
+  const transform: Transform<Source<A>, AsyncGenerator<A>> = async function * (source) {
     for await (const d of source) {
       if (pausePromise !== undefined) {
         await pausePromise


### PR DESCRIPTION
libp2p streams are now explicit about the types of sync/sources they provide, showing that they are `AsyncGenerator`s and not just `AsyncIterable`s.

Refs: https://github.com/achingbrain/it-stream-types/pull/45

BREAKING CHANGE: the type of the source/sink properties have changed