### PR TITLE
fix: improve decode performance with subarray

### DIFF
--- a/src/decode.ts
+++ b/src/decode.ts
@@ -95,7 +95,7 @@ export class Decoder {
       return
     }
 
-    const header = decodeHeader(this.buffer.slice(0, HEADER_LENGTH))
+    const header = decodeHeader(this.buffer.subarray(0, HEADER_LENGTH))
     this.buffer.consume(HEADER_LENGTH)
     return header
   }


### PR DESCRIPTION
Related to #42 

`subarray` may reuse the underlying buffer instead of copying