### PR TITLE
feat: add message byte batching

### DIFF
--- a/package.json
+++ b/package.json
@@ -174,6 +174,7 @@
     "@libp2p/interface": "^0.1.0",
     "@libp2p/logger": "^3.0.0",
     "abortable-iterator": "^5.0.1",
+    "it-batched-bytes": "^2.0.3",
     "it-foreach": "^2.0.3",
     "it-pipe": "^3.0.1",
     "it-pushable": "^3.2.0",

--- a/src/config.ts
+++ b/src/config.ts
@@ -52,6 +52,18 @@ export interface Config {
    * This ensures that a single stream doesn't hog a connection.
    */
   maxMessageSize: number
+
+  /**
+   * Each byte array written into a multiplexed stream is converted to one or
+   * more messages which are sent as byte arrays to the remote node. Sending
+   * lots of small messages can be expensive - use this setting to batch up
+   * the serialized bytes of all messages sent during the current tick up to
+   * this limit to send in one go similar to Nagle's algorithm. N.b. you
+   * should benchmark your application carefully when using this setting as it
+   * may cause the opposite of the desired effect. Omit this setting to send
+   * all messages as they become available. (default: 0)
+   */
+  minSendBytes: number
 }
 
 export const defaultConfig: Config = {
@@ -62,7 +74,8 @@ export const defaultConfig: Config = {
   maxOutboundStreams: 1_000,
   initialStreamWindowSize: INITIAL_STREAM_WINDOW,
   maxStreamWindowSize: MAX_STREAM_WINDOW,
-  maxMessageSize: 64 * 1024
+  maxMessageSize: 64 * 1024,
+  minSendBytes: 0
 }
 
 export function verifyConfig (config: Config): void {
@@ -86,5 +99,8 @@ export function verifyConfig (config: Config): void {
   }
   if (config.maxMessageSize < 1024) {
     throw new CodeError('MaxMessageSize must be greater than a kilobyte', ERR_INVALID_CONFIG)
+  }
+  if (config.minSendBytes < 0) {
+    throw new CodeError('MinSendBytes must be greater or equal to 0', ERR_INVALID_CONFIG)
   }
 }


### PR DESCRIPTION
- Implement the mplex feature from https://github.com/libp2p/js-libp2p-mplex/pull/235

cc @achingbrain I haven't been able to replicate the benefits, and the benchmarks still show mplex being faster in apples to apples comparisons
In many cases this is significantly worse