### PR TITLE
feat!: yield uint8arraylists

### DIFF
--- a/package.json
+++ b/package.json
@@ -168,8 +168,8 @@
     "docs": "aegir docs"
   },
   "dependencies": {
-    "@libp2p/interface": "^0.1.0",
-    "@libp2p/logger": "^3.0.0",
+    "@libp2p/interface": "^1.0.0",
+    "@libp2p/utils": "^5.0.0",
     "get-iterator": "^2.0.1",
     "it-foreach": "^2.0.3",
     "it-pipe": "^3.0.1",
@@ -178,8 +178,9 @@
   },
   "devDependencies": {
     "@dapplion/benchmark": "^0.2.4",
-    "@libp2p/interface-compliance-tests": "^4.0.0",
-    "@libp2p/mplex": "^9.0.0",
+    "@libp2p/interface-compliance-tests": "^5.0.0",
+    "@libp2p/logger": "^4.0.0",
+    "@libp2p/mplex": "^10.0.0",
     "aegir": "^41.1.10",
     "it-drain": "^3.0.2",
     "it-pair": "^2.0.6",

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,16 +1,8 @@
 import { CodeError } from '@libp2p/interface/errors'
-import { logger, type Logger } from '@libp2p/logger'
 import { ERR_INVALID_CONFIG, INITIAL_STREAM_WINDOW, MAX_STREAM_WINDOW } from './constants.js'
 
 // TOOD use config items or delete them
 export interface Config {
-  /**
-   * Used to control the log destination
-   *
-   * It can be disabled by explicitly setting to `undefined`
-   */
-  log?: Logger
-
   /**
    * Used to do periodic keep alive messages using a ping.
    */
@@ -55,7 +47,6 @@ export interface Config {
 }
 
 export const defaultConfig: Config = {
-  log: logger('libp2p:yamux'),
   enableKeepAlive: true,
   keepAliveInterval: 30_000,
   maxInboundStreams: 1_000,

--- a/src/decode.ts
+++ b/src/decode.ts
@@ -1,4 +1,4 @@
-import { CodeError } from '@libp2p/interface/errors'
+import { CodeError } from '@libp2p/interface'
 import { Uint8ArrayList } from 'uint8arraylist'
 import { ERR_DECODE_INVALID_VERSION, ERR_DECODE_IN_PROGRESS } from './constants.js'
 import { type FrameHeader, FrameType, HEADER_LENGTH, YAMUX_VERSION } from './frame.js'

--- a/src/index.ts
+++ b/src/index.ts
@@ -79,11 +79,15 @@
 
 import { Yamux } from './muxer.js'
 import type { YamuxMuxerInit } from './muxer.js'
-import type { StreamMuxerFactory } from '@libp2p/interface/stream-muxer'
+import type { ComponentLogger, StreamMuxerFactory } from '@libp2p/interface'
 
 export { GoAwayCode, type FrameHeader, type FrameType } from './frame.js'
 export type { YamuxMuxerInit }
 
-export function yamux (init: YamuxMuxerInit = {}): () => StreamMuxerFactory {
-  return () => new Yamux(init)
+export interface YamuxMuxerComponents {
+  logger: ComponentLogger
+}
+
+export function yamux (init: YamuxMuxerInit = {}): (components: YamuxMuxerComponents) => StreamMuxerFactory {
+  return (components) => new Yamux(components, init)
 }

--- a/src/stream.ts
+++ b/src/stream.ts
@@ -1,5 +1,5 @@
-import { CodeError } from '@libp2p/interface/errors'
-import { AbstractStream, type AbstractStreamInit } from '@libp2p/interface/stream-muxer/stream'
+import { CodeError } from '@libp2p/interface'
+import { AbstractStream, type AbstractStreamInit } from '@libp2p/utils/abstract-stream'
 import each from 'it-foreach'
 import { ERR_RECV_WINDOW_EXCEEDED, ERR_STREAM_ABORT, INITIAL_STREAM_WINDOW } from './constants.js'
 import { Flag, type FrameHeader, FrameType, HEADER_LENGTH } from './frame.js'
@@ -17,7 +17,7 @@ export enum StreamState {
 
 export interface YamuxStreamInit extends AbstractStreamInit {
   name?: string
-  sendFrame(header: FrameHeader, body?: Uint8Array): void
+  sendFrame(header: FrameHeader, body?: Uint8ArrayList): void
   getRTT(): number
   config: Config
   state: StreamState
@@ -49,7 +49,7 @@ export class YamuxStream extends AbstractStream {
   private epochStart: number
   private readonly getRTT: () => number
 
-  private readonly sendFrame: (header: FrameHeader, body?: Uint8Array) => void
+  private readonly sendFrame: (header: FrameHeader, body?: Uint8ArrayList) => void
 
   constructor (init: YamuxStreamInit) {
     super({
@@ -115,7 +115,7 @@ export class YamuxStream extends AbstractStream {
         flag: flags,
         streamID: this._id,
         length: toSend
-      }, buf.subarray(0, toSend))
+      }, buf.sublist(0, toSend))
 
       this.sendWindowCapacity -= toSend
 

--- a/test/compliance.spec.ts
+++ b/test/compliance.spec.ts
@@ -1,12 +1,15 @@
 /* eslint-env mocha */
 
 import tests from '@libp2p/interface-compliance-tests/stream-muxer'
+import { defaultLogger } from '@libp2p/logger'
 import { TestYamux } from './util.js'
 
 describe('compliance', () => {
   tests({
     async setup () {
-      return new TestYamux({})
+      return new TestYamux({
+        logger: defaultLogger()
+      })
     },
     async teardown () {}
   })

--- a/test/mplex.util.ts
+++ b/test/mplex.util.ts
@@ -1,10 +1,14 @@
+import { defaultLogger } from '@libp2p/logger'
 import { mplex } from '@libp2p/mplex'
 import { duplexPair } from 'it-pair/duplex'
 import { pipe } from 'it-pipe'
+import { type Uint8ArrayList } from 'uint8arraylist'
 import type { StreamMuxer, StreamMuxerInit } from '@libp2p/interface/stream-muxer'
 import type { Source, Transform } from 'it-stream-types'
 
-const factory = mplex()()
+const factory = mplex()({
+  logger: defaultLogger()
+})
 
 export function testYamuxMuxer (name: string, client: boolean, conf: StreamMuxerInit = {}): StreamMuxer {
   return factory.createStreamMuxer({
@@ -54,14 +58,14 @@ export function testClientServer (conf: StreamMuxerInit = {}): {
     unpauseWrite(): void
   }
 } {
-  const pair = duplexPair<Uint8Array>()
+  const pair = duplexPair<Uint8Array | Uint8ArrayList>()
   const client = testYamuxMuxer('libp2p:mplex:client', true, conf)
   const server = testYamuxMuxer('libp2p:mplex:server', false, conf)
 
-  const clientReadTransform = pauseableTransform<Uint8Array>()
-  const clientWriteTransform = pauseableTransform<Uint8Array>()
-  const serverReadTransform = pauseableTransform<Uint8Array>()
-  const serverWriteTransform = pauseableTransform<Uint8Array>()
+  const clientReadTransform = pauseableTransform<Uint8Array | Uint8ArrayList>()
+  const clientWriteTransform = pauseableTransform<Uint8Array | Uint8ArrayList>()
+  const serverReadTransform = pauseableTransform<Uint8Array | Uint8ArrayList>()
+  const serverWriteTransform = pauseableTransform<Uint8Array | Uint8ArrayList>()
 
   void pipe(pair[0], clientReadTransform.transform, client, clientWriteTransform.transform, pair[0])
   void pipe(pair[1], serverReadTransform.transform, server, serverWriteTransform.transform, pair[1])

--- a/test/muxer.spec.ts
+++ b/test/muxer.spec.ts
@@ -3,6 +3,7 @@
 import { expect } from 'aegir/chai'
 import { duplexPair } from 'it-pair/duplex'
 import { pipe } from 'it-pipe'
+import { type Uint8ArrayList } from 'uint8arraylist'
 import { ERR_MUXER_LOCAL_CLOSED } from '../src/constants.js'
 import { sleep, testClientServer, testYamuxMuxer, type YamuxFixture } from './util.js'
 
@@ -29,7 +30,7 @@ describe('muxer', () => {
   })
 
   it('test client<->client', async () => {
-    const pair = duplexPair<Uint8Array>()
+    const pair = duplexPair<Uint8Array | Uint8ArrayList>()
     const client1 = testYamuxMuxer('libp2p:yamux:1', true)
     const client2 = testYamuxMuxer('libp2p:yamux:2', true)
     void pipe(pair[0], client1, pair[0])
@@ -44,7 +45,7 @@ describe('muxer', () => {
   })
 
   it('test server<->server', async () => {
-    const pair = duplexPair<Uint8Array>()
+    const pair = duplexPair<Uint8Array | Uint8ArrayList>()
     const client1 = testYamuxMuxer('libp2p:yamux:1', false)
     const client2 = testYamuxMuxer('libp2p:yamux:2', false)
     void pipe(pair[0], client1, pair[0])


### PR DESCRIPTION
The general pattern of stream muxers is to yield protocol stream data framed by some additional metadata - stream id, flags, etc.

The frame data can be prepended/appended to the protocol stream data by using a `Uint8ArrayList` instead of a `Uint8Array`, this removes the need to copy the protocol data into a new `Uint8Array` for every frame.

The new `@libp2p/interface` version allows muxers to emit `Uint8ArrayList`s as well as `Uint8Array`s so we can send protocol stream data to a transport in a no-copy operation.

In particular yielding a single `Uint8ArrayList` with the frame header plus the data buffer gets us close to that target 200ms connection establishment time:

<img width="725" alt="image" src="https://github.com/ChainSafe/js-libp2p-yamux/assets/665810/306fff6a-56c8-4899-b626-59ac4f6b4ea6">

BREAKING CHANGE: requires `js-libp2p@1.0.0`