### PR TITLE
refactor: make components and logger optional

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -85,9 +85,9 @@ export { GoAwayCode, type FrameHeader, type FrameType } from './frame.js'
 export type { YamuxMuxerInit }
 
 export interface YamuxMuxerComponents {
-  logger: ComponentLogger
+  logger?: ComponentLogger
 }
 
-export function yamux (init: YamuxMuxerInit = {}): (components: YamuxMuxerComponents) => StreamMuxerFactory {
-  return (components) => new Yamux(components, init)
+export function yamux (init: YamuxMuxerInit = {}): (components?: YamuxMuxerComponents) => StreamMuxerFactory {
+  return (components) => new Yamux(components ?? {}, init)
 }

--- a/src/muxer.ts
+++ b/src/muxer.ts
@@ -47,7 +47,7 @@ export class YamuxMuxer implements StreamMuxer {
 
   private readonly config: Config
   private readonly log?: Logger
-  private readonly logger: ComponentLogger
+  private readonly logger?: ComponentLogger
 
   /** Used to close the muxer from either the sink or source */
   private readonly closeController: AbortController
@@ -82,7 +82,7 @@ export class YamuxMuxer implements StreamMuxer {
     this.client = init.direction === 'outbound'
     this.config = { ...defaultConfig, ...init }
     this.logger = components.logger
-    this.log = this.logger.forComponent('libp2p:yamux')
+    this.log = this.logger?.forComponent('libp2p:yamux')
     verifyConfig(this.config)
 
     this.closeController = new AbortController()
@@ -364,7 +364,7 @@ export class YamuxMuxer implements StreamMuxer {
         this.closeStream(id)
         this.onStreamEnd?.(stream)
       },
-      log: this.logger.forComponent(`libp2p:yamux:${direction}:${id}`),
+      log: this.logger?.forComponent(`libp2p:yamux:${direction}:${id}`),
       config: this.config,
       getRTT: this.getRTT.bind(this)
     })


### PR DESCRIPTION
In previous releases of yamux the following was supported:

```
import { yamux } from '@chainsafe/libp2p-yamux'
const muxer = yamux()()
```

Now the following is required:

```
import { yamux } from '@chainsafe/libp2p-yamux'
const muxer = yamux()({logger: ...})
```

Adjust the code to support passing an empty logger and an empty Components.

Fixes #69