### PR TITLE
fix: send data during graceful close.

### DIFF
--- a/src/stream.ts
+++ b/src/stream.ts
@@ -98,12 +98,14 @@ export class YamuxStream extends AbstractStream {
     while (buf.byteLength !== 0) {
       // wait for the send window to refill
       if (this.sendWindowCapacity === 0) {
+        this.log?.trace('wait for send window capacity', this.status)
         await this.waitForSendWindowCapacity(options)
-      }
 
-      // check we didn't close while waiting for send window capacity
-      if (this.status !== 'open') {
-        return
+        // check we didn't close while waiting for send window capacity
+        if (this.status === 'closed' || this.status === 'aborted' || this.status === 'reset') {
+          this.log?.trace('%s while waiting for send window capacity', this.status)
+          return
+        }
       }
 
       // send as much as we can


### PR DESCRIPTION
When a stream is closed gracefully, it's status goes from `'open'` to `'closing'` then to either `'closed'`, `'aborted'` or `'reset'`.

While it's `'closing'` we should still try to send any queued data, this can be aborted by calling `.abort` on the stream or by the signal passed to `.close` firing the `'abort'` event.

This change makes the tests added in https://github.com/libp2p/js-libp2p/pull/2398 pass, in particular the one where we use `it-byte-stream` and write data larger than the send capacity.  When this happens we wait for the remote to signal to accept more data, during which time the stream is closed gracefully and the data ends up being truncated as we stop sending when `this.status` is no longer `'open'`.