### PR TITLE
feat: add service capabilities definition

### DIFF
--- a/package.json
+++ b/package.json
@@ -172,7 +172,7 @@
     "docs": "aegir docs"
   },
   "dependencies": {
-    "@libp2p/interface": "^1.1.3",
+    "@libp2p/interface": "^1.5.0",
     "@libp2p/utils": "^5.2.5",
     "get-iterator": "^2.0.1",
     "it-foreach": "^2.0.6",

--- a/src/muxer.ts
+++ b/src/muxer.ts
@@ -1,4 +1,4 @@
-import { CodeError, setMaxListeners } from '@libp2p/interface'
+import { CodeError, serviceCapabilities, setMaxListeners } from '@libp2p/interface'
 import { getIterator } from 'get-iterator'
 import { pushable, type Pushable } from 'it-pushable'
 import { Uint8ArrayList } from 'uint8arraylist'
@@ -27,6 +27,12 @@ export class Yamux implements StreamMuxerFactory {
     this._components = components
     this._init = init
   }
+
+  readonly [Symbol.toStringTag] = '@chainsafe/libp2p-yamux'
+
+  readonly [serviceCapabilities]: string[] = [
+    '@libp2p/stream-multiplexing'
+  ]
 
   createStreamMuxer (init?: YamuxMuxerInit): YamuxMuxer {
     return new YamuxMuxer(this._components, {


### PR DESCRIPTION
The latest libp2p release allows services to declare their capabilities (what they provide to the node) and their dependencies (the capabilities they require other services to provide for the config to be "valid").

Adds the `serviceCapabilities` symbol property that says Yamux provides the `@libp2p/stream-multiplexing` capability.