### PR TITLE
fix: switch missing stream log to trace

### DIFF
--- a/src/muxer.ts
+++ b/src/muxer.ts
@@ -499,7 +499,7 @@ export class YamuxMuxer implements StreamMuxer {
         }
         await readData()
       } else {
-        this.log?.('frame for missing stream id=%s', streamID)
+        this.log?.trace('frame for missing stream id=%s', streamID)
       }
       return
     }


### PR DESCRIPTION
This happens frequently when a stream has been closed locally but the remote is still sending data and makes the logs very chatty:

<img width="450" alt="image" src="https://github.com/user-attachments/assets/2b52478e-5617-45dd-90f9-4f6ddfc4c75c">
