### PR TITLE
Fix collision with JS override mistake

### DIFF
--- a/src/decode.ts
+++ b/src/decode.ts
@@ -127,13 +127,13 @@ export class Decoder {
 export function returnlessSource<T> (source: Source<T>): Source<T> {
   if ((source as Iterable<T>)[Symbol.iterator] !== undefined) {
     const iterator = (source as Iterable<T>)[Symbol.iterator]()
-    iterator.return = undefined
+    Object.defineProperty(iterator, 'return', {})
     return {
       [Symbol.iterator] () { return iterator }
     }
   } else if ((source as AsyncIterable<T>)[Symbol.asyncIterator] !== undefined) {
     const iterator = (source as AsyncIterable<T>)[Symbol.asyncIterator]()
-    iterator.return = undefined
+    Object.defineProperty(iterator, 'return', {})
     return {
       [Symbol.asyncIterator] () { return iterator }
     }


### PR DESCRIPTION
The `returnlessSource` function stumbles over the infamous Javascript assignment override mistake (which is to say, it throws a `TypeError` that it very much should not be throwing) if running in a locked down environment where the primordials are frozen.  The fix is to use `defineProperty` instead of direct assignment in the sensitive property updates.