### PR TITLE
fix: keep-alive memory leak

### DIFF
--- a/package.json
+++ b/package.json
@@ -177,6 +177,7 @@
     "it-foreach": "^2.0.6",
     "it-pushable": "^3.2.3",
     "it-stream-types": "^2.0.1",
+    "race-signal": "^1.1.3",
     "uint8arraylist": "^2.4.8"
   },
   "devDependencies": {

--- a/src/muxer.ts
+++ b/src/muxer.ts
@@ -1,6 +1,7 @@
 import { InvalidParametersError, MuxerClosedError, TooManyOutboundProtocolStreamsError, serviceCapabilities, setMaxListeners } from '@libp2p/interface'
 import { getIterator } from 'get-iterator'
 import { pushable } from 'it-pushable'
+import { raceSignal } from 'race-signal'
 import { Uint8ArrayList } from 'uint8arraylist'
 import { defaultConfig, verifyConfig } from './config.js'
 import { PROTOCOL_ERRORS } from './constants.js'
@@ -395,17 +396,16 @@ export class YamuxMuxer implements StreamMuxer {
   }
 
   private async keepAliveLoop (): Promise<void> {
-    const abortPromise = new Promise((_resolve, reject) => { this.closeController.signal.addEventListener('abort', reject, { once: true }) })
     this.log?.trace('muxer keepalive enabled interval=%s', this.config.keepAliveInterval)
     while (true) {
       let timeoutId
       try {
-        await Promise.race([
-          abortPromise,
+        await raceSignal(
           new Promise((resolve) => {
             timeoutId = setTimeout(resolve, this.config.keepAliveInterval)
-          })
-        ])
+          }),
+          this.closeController.signal
+        )
         this.ping().catch(e => this.log?.error('ping error: %s', e))
       } catch (e) {
         // closed


### PR DESCRIPTION
The listener added to the close controller's abort signal is never removed until the muxer is closed which causes a small leak.